### PR TITLE
feat: allow creation of schema with `additionalProperties: false`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omniscient-ai/genson-js",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.js",
   "author": "Skye Brady <skye.brady@omniscient.uk.com>",

--- a/src/schema-builder.ts
+++ b/src/schema-builder.ts
@@ -53,6 +53,9 @@ function createSchemaForObject(
   if (!options?.noRequired) {
     schema.required = keys;
   }
+  if (options?.noAdditionalProperties) {
+    schema.additionalProperties = false;
+  }
   return schema;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,10 +14,13 @@ export type Schema = {
   properties?: Record<string, Schema>;
   required?: string[];
   anyOf?: Array<Schema>;
+  additionalProperties?: {type: ValueType | ValueType[]} | false;
+  [key: `\$${string}`]: string
 };
 
 export type SchemaGenOptions = {
-  noRequired: boolean;
+  noRequired?: boolean;
+  noAdditionalProperties?: boolean;
 };
 
 export type SchemaComparisonOptions = {

--- a/tests/schema-builder.spec.ts
+++ b/tests/schema-builder.spec.ts
@@ -305,6 +305,22 @@ describe("SchemaBuilder", () => {
           },
         });
       });
+
+      it("should generate schema for object w/o additional properties allowed", () => {
+        const schema = createSchema(
+          { one: "a", two: "b" },
+          { noAdditionalProperties: true },
+        );
+        expect(schema).toEqual({
+          type: "object",
+          properties: {
+            one: { type: "string" },
+            two: { type: "string" },
+          },
+          additionalProperties: false,
+          required: ["one", "two"],
+        });
+      });
     });
 
     describe("prototype methods", () => {


### PR DESCRIPTION
Exposes option to create schema specifying `additionalProperties: false`

Also amends the schema type to allow for $keywords